### PR TITLE
Migrate to Wrangler v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,5 @@ jspm_packages/
 common/temp/
 **/.rush/temp/
 
-# Wrangler/Webpack output
-worker/
-dist/
+# Build output
 build/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,1 @@
-dist/
-worker/
 build/

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -13,6 +13,7 @@ specifiers:
   esbuild: ^0.14.43
   handlebars: ^4.7.7
   prettier: ^2.1.2
+  wrangler: ^2.0.16
 
 dependencies:
   '@hapi/boom': 9.1.4
@@ -27,8 +28,33 @@ dependencies:
   esbuild: 0.14.43
   handlebars: 4.7.7
   prettier: 2.3.2
+  wrangler: 2.0.16
 
 packages:
+
+  /@cloudflare/kv-asset-handler/0.2.0:
+    resolution: {integrity: sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==}
+    dependencies:
+      mime: 3.0.0
+    dev: false
+
+  /@esbuild-plugins/node-globals-polyfill/0.1.1_esbuild@0.14.47:
+    resolution: {integrity: sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==}
+    peerDependencies:
+      esbuild: '*'
+    dependencies:
+      esbuild: 0.14.47
+    dev: false
+
+  /@esbuild-plugins/node-modules-polyfill/0.1.4_esbuild@0.14.47:
+    resolution: {integrity: sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==}
+    peerDependencies:
+      esbuild: '*'
+    dependencies:
+      esbuild: 0.14.47
+      escape-string-regexp: 4.0.0
+      rollup-plugin-node-polyfills: 0.2.1
+    dev: false
 
   /@hapi/boom/9.1.4:
     resolution: {integrity: sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==}
@@ -47,8 +73,207 @@ packages:
     resolution: {integrity: sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==}
     dev: false
 
+  /@iarna/toml/2.2.5:
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+    dev: false
+
+  /@miniflare/cache/2.6.0:
+    resolution: {integrity: sha512-4oh8MgpquoxaslI7Z8sMzmEZR0Dc+L3aEh69o9d8ZCs4nUdOENnfKlY50O5nEnL7nhhyAljkMBaXD2wAH2DLeQ==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/core': 2.6.0
+      '@miniflare/shared': 2.6.0
+      http-cache-semantics: 4.1.0
+      undici: 5.5.1
+    dev: false
+
+  /@miniflare/cli-parser/2.6.0:
+    resolution: {integrity: sha512-dJDoIPAUqWhzvBHHyqyhobdzDedBYRWZ4yItBi9m4MTU/EneLJ5jryB340SwUnmtBMZxUh/LWdAuUEkKpdVNyA==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.6.0
+      kleur: 4.1.5
+    dev: false
+
+  /@miniflare/core/2.6.0:
+    resolution: {integrity: sha512-CmofhIRot++GI7NHPMwzNb65+0hWLN186L91BrH/doPVHnT/itmEfzYQpL9bFLD0c/i14dfv+IUNetDdGEBIrw==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@iarna/toml': 2.2.5
+      '@miniflare/shared': 2.6.0
+      '@miniflare/watcher': 2.6.0
+      busboy: 1.6.0
+      dotenv: 10.0.0
+      kleur: 4.1.5
+      set-cookie-parser: 2.5.0
+      undici: 5.5.1
+      urlpattern-polyfill: 4.0.3
+    dev: false
+
+  /@miniflare/durable-objects/2.6.0:
+    resolution: {integrity: sha512-uzWoGFtkIIh3m3HAzqd5f86nOSC0xFli6dq2q7ilE3UjgouOcLqObxJyE/IzvSwsj4DUWFv6//YDfHihK2fGAA==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/core': 2.6.0
+      '@miniflare/shared': 2.6.0
+      '@miniflare/storage-memory': 2.6.0
+      undici: 5.5.1
+    dev: false
+
+  /@miniflare/html-rewriter/2.6.0:
+    resolution: {integrity: sha512-+JqFlIDLzstb/Spj+j/kI6uHzolrqjsMks3Tf24Q4YFo9YYdZguqUFcDz2yr79ZTP/SKXaZH+AYqosnJps4dHQ==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/core': 2.6.0
+      '@miniflare/shared': 2.6.0
+      html-rewriter-wasm: 0.4.1
+      undici: 5.5.1
+    dev: false
+
+  /@miniflare/http-server/2.6.0:
+    resolution: {integrity: sha512-FhcAVIpipMEzMCsJBc/b0JhNEJ66GPX60vA2NcqjGKHYbwoPCPlwCFQq2giPzW/R95ugrEjPfo4/5Q4UbnpoGA==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/core': 2.6.0
+      '@miniflare/shared': 2.6.0
+      '@miniflare/web-sockets': 2.6.0
+      kleur: 4.1.5
+      selfsigned: 2.0.1
+      undici: 5.5.1
+      ws: 8.8.0
+      youch: 2.2.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@miniflare/kv/2.6.0:
+    resolution: {integrity: sha512-7Q+Q0Wwinsz85qpKLlBeXSCLweiVowpMJ5AmQpmELnTya59HQ24cOUHxPd64hXFhdYXVIxOmk6lQaZ21JhdHGQ==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.6.0
+    dev: false
+
+  /@miniflare/r2/2.6.0:
+    resolution: {integrity: sha512-Ymbqu17ajtuk9b11txF2h1Ewqqlu3XCCpAwAgCQa6AK1yRidQECCPq9w9oXZxE1p5aaSuLTOUbgSdtveFCsLxQ==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.6.0
+      undici: 5.5.1
+    dev: false
+
+  /@miniflare/runner-vm/2.6.0:
+    resolution: {integrity: sha512-ZxsiVMMUcjb01LwrO2t50YbU5PT5s3k7DrmR5185R/n04K5BikqZz8eQf8lKlQQYem0BROqmmQgurZGw0a2HUw==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.6.0
+    dev: false
+
+  /@miniflare/scheduler/2.6.0:
+    resolution: {integrity: sha512-BM+RDF+8twkTCOb7Oz0NIs5phzAVJ/Gx7tFZR23fGsZjWRnE3TBeqfzaNutU9pcoWDZtBQqEJMeTeb0KZTo75Q==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/core': 2.6.0
+      '@miniflare/shared': 2.6.0
+      cron-schedule: 3.0.6
+    dev: false
+
+  /@miniflare/shared/2.6.0:
+    resolution: {integrity: sha512-/7k4C37GF0INu99LNFmFhHYL6U9/oRY/nWDa5sr6+lPEKKm2rkmfvDIA+YNAj7Ql61ZWMgEMj0S3NhV0rWkj7Q==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      ignore: 5.2.0
+      kleur: 4.1.5
+    dev: false
+
+  /@miniflare/sites/2.6.0:
+    resolution: {integrity: sha512-XfWhpREC638LOGNmuHaPn1MAz1sh2mz+VdMsjRCzUo6NwPl4IcUhnorJR62Xr0qmI/RqVMTZbvzrChXio4Bi4A==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/kv': 2.6.0
+      '@miniflare/shared': 2.6.0
+      '@miniflare/storage-file': 2.6.0
+    dev: false
+
+  /@miniflare/storage-file/2.6.0:
+    resolution: {integrity: sha512-xprDVJClQ2X1vXVPM16WQZz3rS+6fNuCYC8bfEFHABDByQoUNDpk8q+m1IpTaFXYivYxRhE+xr7eK2QQP068tA==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.6.0
+      '@miniflare/storage-memory': 2.6.0
+    dev: false
+
+  /@miniflare/storage-memory/2.6.0:
+    resolution: {integrity: sha512-0EwELTG2r6IC4AMlQv0YXRZdw9g/lCydceuGKeFkWAVb55pY+yMBxkJO9VV7QOrEx8MLsR8tsfl5SBK3AkfLtA==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.6.0
+    dev: false
+
+  /@miniflare/watcher/2.6.0:
+    resolution: {integrity: sha512-mttfhNDmEIFo2rWF73JeWj1TLN+3cQC1TFhbtLApz9bXilLywArXMYqDJGA8PUnJCFM/8k2FDjaFNiPy6ggIJw==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.6.0
+    dev: false
+
+  /@miniflare/web-sockets/2.6.0:
+    resolution: {integrity: sha512-ePbcuP9LrStVTllZzqx2oNVoOpceyU3jJF3nGDMNW5+bqB+BdeTggSF8rhER7omcSCswCMY2Do6VelIcAXHkXA==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/core': 2.6.0
+      '@miniflare/shared': 2.6.0
+      undici: 5.5.1
+      ws: 8.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@types/stack-trace/0.0.29:
+    resolution: {integrity: sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==}
+    dev: false
+
+  /blake3-wasm/2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+    dev: false
+
+  /buffer-from/1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: false
+
+  /busboy/1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+    dependencies:
+      streamsearch: 1.1.0
+    dev: false
+
+  /cookie/0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /cron-schedule/3.0.6:
+    resolution: {integrity: sha512-izfGgKyzzIyLaeb1EtZ3KbglkS6AKp9cv7LxmiyoOu+fXfol1tQDC0Cof0enVZGNtudTHW+3lfuW9ZkLQss4Wg==}
+    dev: false
+
+  /dotenv/10.0.0:
+    resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
+    engines: {node: '>=10'}
+    dev: false
+
   /esbuild-android-64/0.14.43:
     resolution: {integrity: sha512-kqFXAS72K6cNrB6RiM7YJ5lNvmWRDSlpi7ZuRZ1hu1S3w0zlwcoCxWAyM23LQUyZSs1PbjHgdbbfYAN8IGh6xg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-android-64/0.14.47:
+    resolution: {integrity: sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -65,8 +290,26 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-android-arm64/0.14.47:
+    resolution: {integrity: sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-darwin-64/0.14.43:
     resolution: {integrity: sha512-/3PSilx011ttoieRGkSZ0XV8zjBf2C9enV4ScMMbCT4dpx0mFhMOpFnCHkOK0pWGB8LklykFyHrWk2z6DENVUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-darwin-64/0.14.47:
+    resolution: {integrity: sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -83,8 +326,26 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-darwin-arm64/0.14.47:
+    resolution: {integrity: sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-freebsd-64/0.14.43:
     resolution: {integrity: sha512-FNWc05TPHYgaXjbPZO5/rJKSBslfG6BeMSs8GhwnqAKP56eEhvmzwnIz1QcC9cRVyO+IKqWNfmHFkCa1WJTULA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-freebsd-64/0.14.47:
+    resolution: {integrity: sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -101,8 +362,26 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-freebsd-arm64/0.14.47:
+    resolution: {integrity: sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-32/0.14.43:
     resolution: {integrity: sha512-KoxoEra+9O3AKVvgDFvDkiuddCds6q71owSQEYwjtqRV7RwbPzKxJa6+uyzUulHcyGVq0g15K0oKG5CFBcvYDw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-32/0.14.47:
+    resolution: {integrity: sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -119,8 +398,26 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-linux-64/0.14.47:
+    resolution: {integrity: sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-arm/0.14.43:
     resolution: {integrity: sha512-e6YzQUoDxxtyamuF12eVzzRC7bbEFSZohJ6igQB9tBqnNmIQY3fI6Cns3z2wxtbZ3f2o6idkD2fQnlvs2902Dg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-arm/0.14.47:
+    resolution: {integrity: sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -137,8 +434,26 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-linux-arm64/0.14.47:
+    resolution: {integrity: sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-mips64le/0.14.43:
     resolution: {integrity: sha512-f+v8cInPEL1/SDP//CfSYzcDNgE4CY3xgDV81DWm3KAPWzhvxARrKxB1Pstf5mB56yAslJDxu7ryBUPX207EZA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-mips64le/0.14.47:
+    resolution: {integrity: sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -155,8 +470,26 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-linux-ppc64le/0.14.47:
+    resolution: {integrity: sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-riscv64/0.14.43:
     resolution: {integrity: sha512-lYcAOUxp85hC7lSjycJUVSmj4/9oEfSyXjb/ua9bNl8afonaduuqtw7hvKMoKuYnVwOCDw4RSfKpcnIRDWq+Bw==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-riscv64/0.14.47:
+    resolution: {integrity: sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -173,8 +506,26 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-linux-s390x/0.14.47:
+    resolution: {integrity: sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-netbsd-64/0.14.43:
     resolution: {integrity: sha512-2mH4QF6hHBn5zzAfxEI/2eBC0mspVsZ6UVo821LpAJKMvLJPBk3XJO5xwg7paDqSqpl7p6IRrAenW999AEfJhQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-netbsd-64/0.14.47:
+    resolution: {integrity: sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -191,8 +542,26 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-openbsd-64/0.14.47:
+    resolution: {integrity: sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-sunos-64/0.14.43:
     resolution: {integrity: sha512-DgxSi9DaHReL9gYuul2rrQCAapgnCJkh3LSHPKsY26zytYppG0HgkgVF80zjIlvEsUbGBP/GHQzBtrezj/Zq1Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-sunos-64/0.14.47:
+    resolution: {integrity: sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -209,6 +578,15 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-windows-32/0.14.47:
+    resolution: {integrity: sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-windows-64/0.14.43:
     resolution: {integrity: sha512-8NsuNfI8xwFuJbrCuI+aBqNTYkrWErejFO5aYM+yHqyHuL8mmepLS9EPzAzk8rvfaJrhN0+RvKWAcymViHOKEw==}
     engines: {node: '>=12'}
@@ -218,8 +596,26 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-windows-64/0.14.47:
+    resolution: {integrity: sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-windows-arm64/0.14.43:
     resolution: {integrity: sha512-7ZlD7bo++kVRblJEoG+cepljkfP8bfuTPz5fIXzptwnPaFwGS6ahvfoYzY7WCf5v/1nX2X02HDraVItTgbHnKw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-windows-arm64/0.14.47:
+    resolution: {integrity: sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -255,6 +651,51 @@ packages:
       esbuild-windows-arm64: 0.14.43
     dev: false
 
+  /esbuild/0.14.47:
+    resolution: {integrity: sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      esbuild-android-64: 0.14.47
+      esbuild-android-arm64: 0.14.47
+      esbuild-darwin-64: 0.14.47
+      esbuild-darwin-arm64: 0.14.47
+      esbuild-freebsd-64: 0.14.47
+      esbuild-freebsd-arm64: 0.14.47
+      esbuild-linux-32: 0.14.47
+      esbuild-linux-64: 0.14.47
+      esbuild-linux-arm: 0.14.47
+      esbuild-linux-arm64: 0.14.47
+      esbuild-linux-mips64le: 0.14.47
+      esbuild-linux-ppc64le: 0.14.47
+      esbuild-linux-riscv64: 0.14.47
+      esbuild-linux-s390x: 0.14.47
+      esbuild-netbsd-64: 0.14.47
+      esbuild-openbsd-64: 0.14.47
+      esbuild-sunos-64: 0.14.47
+      esbuild-windows-32: 0.14.47
+      esbuild-windows-64: 0.14.47
+      esbuild-windows-arm64: 0.14.47
+    dev: false
+
+  /escape-string-regexp/4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /estree-walker/0.6.1:
+    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+    dev: false
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /handlebars/4.7.7:
     resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
     engines: {node: '>=0.4.7'}
@@ -268,12 +709,102 @@ packages:
       uglify-js: 3.16.0
     dev: false
 
+  /html-rewriter-wasm/0.4.1:
+    resolution: {integrity: sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q==}
+    dev: false
+
+  /http-cache-semantics/4.1.0:
+    resolution: {integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==}
+    dev: false
+
+  /ignore/5.2.0:
+    resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
+    engines: {node: '>= 4'}
+    dev: false
+
+  /kleur/4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /magic-string/0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: false
+
+  /mime/3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dev: false
+
+  /miniflare/2.6.0:
+    resolution: {integrity: sha512-KDAQZV2aDZ044X1ihlCIa6DPdq1w3fUJFW4xZ+r+DPUxj9t1AuehjR9Fc6zCmZQrk12gLXDSZSyNft1ozm1X7Q==}
+    engines: {node: '>=16.7'}
+    hasBin: true
+    peerDependencies:
+      '@miniflare/storage-redis': 2.6.0
+      cron-schedule: ^3.0.4
+      ioredis: ^4.27.9
+    peerDependenciesMeta:
+      '@miniflare/storage-redis':
+        optional: true
+      cron-schedule:
+        optional: true
+      ioredis:
+        optional: true
+    dependencies:
+      '@miniflare/cache': 2.6.0
+      '@miniflare/cli-parser': 2.6.0
+      '@miniflare/core': 2.6.0
+      '@miniflare/durable-objects': 2.6.0
+      '@miniflare/html-rewriter': 2.6.0
+      '@miniflare/http-server': 2.6.0
+      '@miniflare/kv': 2.6.0
+      '@miniflare/r2': 2.6.0
+      '@miniflare/runner-vm': 2.6.0
+      '@miniflare/scheduler': 2.6.0
+      '@miniflare/shared': 2.6.0
+      '@miniflare/sites': 2.6.0
+      '@miniflare/storage-file': 2.6.0
+      '@miniflare/storage-memory': 2.6.0
+      '@miniflare/web-sockets': 2.6.0
+      kleur: 4.1.5
+      semiver: 1.1.0
+      source-map-support: 0.5.21
+      undici: 5.5.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
     dev: false
 
+  /mustache/4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+    dev: false
+
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: false
+
   /neo-async/2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+    dev: false
+
+  /node-forge/1.3.1:
+    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+    engines: {node: '>= 6.13.0'}
+    dev: false
+
+  /path-to-regexp/6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
     dev: false
 
   /prettier/2.3.2:
@@ -282,9 +813,66 @@ packages:
     hasBin: true
     dev: false
 
+  /rollup-plugin-inject/3.0.2:
+    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
+    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
+    dependencies:
+      estree-walker: 0.6.1
+      magic-string: 0.25.9
+      rollup-pluginutils: 2.8.2
+    dev: false
+
+  /rollup-plugin-node-polyfills/0.2.1:
+    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
+    dependencies:
+      rollup-plugin-inject: 3.0.2
+    dev: false
+
+  /rollup-pluginutils/2.8.2:
+    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+    dependencies:
+      estree-walker: 0.6.1
+    dev: false
+
+  /selfsigned/2.0.1:
+    resolution: {integrity: sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      node-forge: 1.3.1
+    dev: false
+
+  /semiver/1.1.0:
+    resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /set-cookie-parser/2.5.0:
+    resolution: {integrity: sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w==}
+    dev: false
+
+  /source-map-support/0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: false
+
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: false
+
+  /stack-trace/0.0.10:
+    resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+    dev: false
+
+  /streamsearch/1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
     dev: false
 
   /uglify-js/3.16.0:
@@ -295,66 +883,176 @@ packages:
     dev: false
     optional: true
 
+  /undici/5.5.1:
+    resolution: {integrity: sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==}
+    engines: {node: '>=12.18'}
+    dev: false
+
+  /urlpattern-polyfill/4.0.3:
+    resolution: {integrity: sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==}
+    dev: false
+
   /wordwrap/1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: false
 
+  /wrangler/2.0.16:
+    resolution: {integrity: sha512-Fx3DCbQcYpnmUfRvCt4e7nxT0s6WVtIgjdBljvqOX6M/Cd1nJae8VpDtYG1XHtMjIkakRqmdtLCFds9a5usZGQ==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.2.0
+      '@esbuild-plugins/node-globals-polyfill': 0.1.1_esbuild@0.14.47
+      '@esbuild-plugins/node-modules-polyfill': 0.1.4_esbuild@0.14.47
+      blake3-wasm: 2.1.5
+      esbuild: 0.14.47
+      miniflare: 2.6.0
+      nanoid: 3.3.4
+      path-to-regexp: 6.2.1
+      selfsigned: 2.0.1
+      semiver: 1.1.0
+      xxhash-wasm: 1.0.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    transitivePeerDependencies:
+      - '@miniflare/storage-redis'
+      - bufferutil
+      - cron-schedule
+      - ioredis
+      - utf-8-validate
+    dev: false
+
+  /ws/8.8.0:
+    resolution: {integrity: sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
+  /xxhash-wasm/1.0.1:
+    resolution: {integrity: sha512-Lc9CTvDrH2vRoiaUzz25q7lRaviMhz90pkx6YxR9EPYtF99yOJnv2cB+CQ0hp/TLoqrUsk8z/W2EN31T568Azw==}
+    dev: false
+
+  /youch/2.2.2:
+    resolution: {integrity: sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==}
+    dependencies:
+      '@types/stack-trace': 0.0.29
+      cookie: 0.4.2
+      mustache: 4.2.0
+      stack-trace: 0.0.10
+    dev: false
+
   file:projects/hero-of-time-link.tgz:
-    resolution: {integrity: sha512-KS2F4XS0mZXzWc80Q9FKETlNZxdH/r53Bcl8d1yQXZzJCcbSncOZgdejtRz3r25jxGqKbtmMhGextgNj+25VyQ==, tarball: file:projects/hero-of-time-link.tgz}
+    resolution: {integrity: sha512-k0QVb1VFYeGU3SpALDZxi2ZRqBdBh6s1pn3H1MrIsHsS7no962gVwnySLMFPhIq/aeH6JDta1kgHgyuogJlzlw==, tarball: file:projects/hero-of-time-link.tgz}
     name: '@rush-temp/hero-of-time-link'
     version: 0.0.0
     dependencies:
       prettier: 2.3.2
+      wrangler: 2.0.16
+    transitivePeerDependencies:
+      - '@miniflare/storage-redis'
+      - bufferutil
+      - cron-schedule
+      - ioredis
+      - utf-8-validate
     dev: false
 
   file:projects/hugo-media-proxy.tgz:
-    resolution: {integrity: sha512-Bco3BG4vLvLVQ+By/onxRkod62JQrvbqi+Bvfjoka3fDoODNhJS1moxNfNbT7eR5IIQFCRtUMNp/C2uwqewwUw==, tarball: file:projects/hugo-media-proxy.tgz}
+    resolution: {integrity: sha512-u8KqSmahMTPAeu2r9t69vgJ8jOEBrpJabjpqxFsX9QVN/IfYYzvUoFiGHxeQH5SN6ktJNpJPJ51JgkkKCoPQtg==, tarball: file:projects/hugo-media-proxy.tgz}
     name: '@rush-temp/hugo-media-proxy'
     version: 0.0.0
     dependencies:
       prettier: 2.3.2
+      wrangler: 2.0.16
+    transitivePeerDependencies:
+      - '@miniflare/storage-redis'
+      - bufferutil
+      - cron-schedule
+      - ioredis
+      - utf-8-validate
     dev: false
 
   file:projects/hugo-proxy.tgz:
-    resolution: {integrity: sha512-K6zkuZGkf2OeYlHE0CGXJ/UZaXKsz9YaqgiLYonvqxd2gB43b+bZVICINkXZTbfhUBxevLuBZXW7ivvUs0tjPQ==, tarball: file:projects/hugo-proxy.tgz}
+    resolution: {integrity: sha512-/T2caq/e/hyQ+cicR0oUcQdCta6L8907DPiqdWzp6vG5CGFv4bkzgP0GcoBMv63vLNcH4TjdJU5WF+2/4TLd5w==, tarball: file:projects/hugo-proxy.tgz}
     name: '@rush-temp/hugo-proxy'
     version: 0.0.0
     dependencies:
       prettier: 2.3.2
+      wrangler: 2.0.16
+    transitivePeerDependencies:
+      - '@miniflare/storage-redis'
+      - bufferutil
+      - cron-schedule
+      - ioredis
+      - utf-8-validate
     dev: false
 
   file:projects/nchlswhttkr-dot-com.tgz:
-    resolution: {integrity: sha512-xBxuaABnMq2ZzgJQ1TELNAbV7mmUywKHZzWcC0iUhjnUQambXroxJeqDqqvwImHoE7ozCgIFOjcPmOKcXUFapw==, tarball: file:projects/nchlswhttkr-dot-com.tgz}
+    resolution: {integrity: sha512-hDvzF/pqQZ3BoaNIcx13Og4JXAPfVcSvt3SnHBv8DAXCnbPxzTZaXZPsA///zD1L6PpBUsY+g71Act4oRdJy9w==, tarball: file:projects/nchlswhttkr-dot-com.tgz}
     name: '@rush-temp/nchlswhttkr-dot-com'
     version: 0.0.0
     dependencies:
       prettier: 2.3.2
+      wrangler: 2.0.16
+    transitivePeerDependencies:
+      - '@miniflare/storage-redis'
+      - bufferutil
+      - cron-schedule
+      - ioredis
+      - utf-8-validate
     dev: false
 
   file:projects/newsletter-subscription-form.tgz:
-    resolution: {integrity: sha512-eElyfKX3d+mdueiqZ2vn/F+H0z+W6v38P0KqtsQNlhl4cvymcPOtrpYiahFB1d43EMd2UxWQFkfRnqjYM8S6yg==, tarball: file:projects/newsletter-subscription-form.tgz}
+    resolution: {integrity: sha512-yLejGg0ziV2g7zvrUtcgrXcIMUIZGzSSmqMIW4Qg88gsjF3nuZf2DoYiCZlTzHWqsCbSyMQgUtUopON7dWY0Wg==, tarball: file:projects/newsletter-subscription-form.tgz}
     name: '@rush-temp/newsletter-subscription-form'
     version: 0.0.0
     dependencies:
       prettier: 2.3.2
+      wrangler: 2.0.16
+    transitivePeerDependencies:
+      - '@miniflare/storage-redis'
+      - bufferutil
+      - cron-schedule
+      - ioredis
+      - utf-8-validate
     dev: false
 
   file:projects/rss-feeds.tgz:
-    resolution: {integrity: sha512-B+CwQUSjkvF3IeAeT2nnuoIbBdue9ZpE8oKuwDHJKa84B3fDZPvj5QTQ/Kl328Es48ove7ySV4/zyJ2TR/qHjA==, tarball: file:projects/rss-feeds.tgz}
+    resolution: {integrity: sha512-tE43DpSP3MxioAxvY247qj1dQpD1iRDISJHRFLE6qEYHBui3wOeSm2sHHKnkAoxR6u4Pvlqh37sKEu1Fj65j9w==, tarball: file:projects/rss-feeds.tgz}
     name: '@rush-temp/rss-feeds'
     version: 0.0.0
     dependencies:
-      esbuild: 0.14.43
+      esbuild: 0.14.47
       handlebars: 4.7.7
       prettier: 2.3.2
+      wrangler: 2.0.16
+    transitivePeerDependencies:
+      - '@miniflare/storage-redis'
+      - bufferutil
+      - cron-schedule
+      - ioredis
+      - utf-8-validate
     dev: false
 
   file:projects/terraform-registry.tgz:
-    resolution: {integrity: sha512-0qaQiG9Dw/A97ta2lNMtA6Haf0eXbN3Sxm9PbJ/Etr6TL5loca5vWXQsdtinll1b35HSlAfCszcVRufl9SPhJQ==, tarball: file:projects/terraform-registry.tgz}
+    resolution: {integrity: sha512-o7YZMWKvP0GocMFycapLhiQsVgqZENjDY+MDzNclG5u0mCrOsL00OAHacxAWiUoblaZBKy2BTtKz/ijCY0rGYA==, tarball: file:projects/terraform-registry.tgz}
     name: '@rush-temp/terraform-registry'
     version: 0.0.0
     dependencies:
       '@hapi/boom': 9.1.4
       '@hapi/call': 8.0.1
       prettier: 2.3.2
+      wrangler: 2.0.16
+    transitivePeerDependencies:
+      - '@miniflare/storage-redis'
+      - bufferutil
+      - cron-schedule
+      - ioredis
+      - utf-8-validate
     dev: false

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -979,10 +979,11 @@ packages:
     dev: false
 
   file:projects/hugo-proxy.tgz:
-    resolution: {integrity: sha512-/T2caq/e/hyQ+cicR0oUcQdCta6L8907DPiqdWzp6vG5CGFv4bkzgP0GcoBMv63vLNcH4TjdJU5WF+2/4TLd5w==, tarball: file:projects/hugo-proxy.tgz}
+    resolution: {integrity: sha512-8er4s8vhVkQdTSe1hjclbfVjbIsxH06vL/gzgD484nS8lnLgjkQ6wZqtPgW48BwTG+tlPMf/Rh08BhxXYrM0sQ==, tarball: file:projects/hugo-proxy.tgz}
     name: '@rush-temp/hugo-proxy'
     version: 0.0.0
     dependencies:
+      esbuild: 0.14.47
       prettier: 2.3.2
       wrangler: 2.0.16
     transitivePeerDependencies:

--- a/workers/hero-of-time-link/build.sh
+++ b/workers/hero-of-time-link/build.sh
@@ -2,10 +2,9 @@
 
 set -euo pipefail
 
-prettier --ignore-path "../../.prettierignore" --check "**/*.js"
+prettier --ignore-path "../../.prettierignore" --check "**/*.(js|json)"
 
-export CF_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
-export CF_API_TOKEN=$(pass show workers/cloudflare-api-token)
-export CF_ZONE_ID=$(pass show workers/cloudflare-zone-id-nicholas.cloud)
+export CLOUDFLARE_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
+export CLOUDFLARE_API_TOKEN=$(pass show workers/cloudflare-api-token)
 
-wrangler publish 2>&1
+wrangler publish

--- a/workers/hero-of-time-link/package.json
+++ b/workers/hero-of-time-link/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "prettier": "^2.1.2"
   },
-  "main": "index.js",
   "dependencies": {
     "wrangler": "^2.0.16"
   }

--- a/workers/hero-of-time-link/package.json
+++ b/workers/hero-of-time-link/package.json
@@ -10,5 +10,8 @@
   "devDependencies": {
     "prettier": "^2.1.2"
   },
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "wrangler": "^2.0.16"
+  }
 }

--- a/workers/hero-of-time-link/wrangler.toml
+++ b/workers/hero-of-time-link/wrangler.toml
@@ -1,4 +1,7 @@
 name = "hero-of-time-link"
-type = "javascript"
+main = "index.js"
+compatibility_date = "2022-07-01"
 route = "nicholas.cloud/goto*"
-kv_namespaces = [{ binding="SHORTCUTS", id="5504ea7cb33b4d2c908da38ebbb6ac29" }]
+kv_namespaces = [
+    { binding="SHORTCUTS", id="5504ea7cb33b4d2c908da38ebbb6ac29" }
+]

--- a/workers/hugo-media-proxy/build.sh
+++ b/workers/hugo-media-proxy/build.sh
@@ -2,10 +2,9 @@
 
 set -euo pipefail
 
-prettier --ignore-path "../../.prettierignore" --check "**/*.js"
+prettier --ignore-path "../../.prettierignore" --check "**/*.(js|json)"
 
-export CF_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
-export CF_API_TOKEN=$(pass show workers/cloudflare-api-token)
-export CF_ZONE_ID=$(pass show workers/cloudflare-zone-id-nicholas.cloud)
+export CLOUDFLARE_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
+export CLOUDFLARE_API_TOKEN=$(pass show workers/cloudflare-api-token)
 
-wrangler publish 2>&1
+wrangler publish

--- a/workers/hugo-media-proxy/package.json
+++ b/workers/hugo-media-proxy/package.json
@@ -1,17 +1,16 @@
 {
-    "name": "@nchlswhttkr/hugo-media-proxy",
-    "version": "0.1.0",
-    "description": "",
-    "scripts": {
-        "build": "source build.sh"
-    },
-    "license": "MIT",
-    "private": true,
-    "devDependencies": {
-        "prettier": "^2.1.2"
-    },
-    "main": "index.js",
-    "dependencies": {
-      "wrangler": "^2.0.16"
-    }
+  "name": "@nchlswhttkr/hugo-media-proxy",
+  "version": "0.1.0",
+  "description": "",
+  "scripts": {
+    "build": "source build.sh"
+  },
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "prettier": "^2.1.2"
+  },
+  "dependencies": {
+    "wrangler": "^2.0.16"
+  }
 }

--- a/workers/hugo-media-proxy/package.json
+++ b/workers/hugo-media-proxy/package.json
@@ -10,5 +10,8 @@
     "devDependencies": {
         "prettier": "^2.1.2"
     },
-    "main": "index.js"
+    "main": "index.js",
+    "dependencies": {
+      "wrangler": "^2.0.16"
+    }
 }

--- a/workers/hugo-media-proxy/wrangler.toml
+++ b/workers/hugo-media-proxy/wrangler.toml
@@ -1,5 +1,6 @@
 name = "hugo-media-proxy"
-type = "javascript"
+main = "index.js"
+compatibility_date = "2022-07-01"
 route = "https://nicholas.cloud/media-proxy/*"
 kv_namespaces = [
     { binding="CACHED_MEDIA", id="c976e3cbe4e24b8a8387e43ec4bf1236" },

--- a/workers/hugo-proxy/build.sh
+++ b/workers/hugo-proxy/build.sh
@@ -2,13 +2,14 @@
 
 set -euo pipefail
 
-prettier --ignore-path "../../.prettierignore" --check "**/*.js"
+prettier --ignore-path "../../.prettierignore" --check "**/*.(js|json)"
+esbuild index.js --bundle --outfile="build/worker.js" --log-level="warning"
 
-export CF_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
-export CF_API_TOKEN=$(pass show workers/cloudflare-api-token)
+export CLOUDFLARE_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
+export CLOUDFLARE_API_TOKEN=$(pass show workers/cloudflare-api-token)
 
 pass show workers/hugo-proxy/writer-secret | wrangler secret put WRITER_SECRET
 pass show workers/hugo-proxy/youtube-secret-key | wrangler secret put YOUTUBE_SECRET_KEY
 pass show workers/hugo-proxy/vimeo-secret-key | wrangler secret put VIMEO_SECRET_KEY
 
-wrangler publish 2>&1
+wrangler publish

--- a/workers/hugo-proxy/package.json
+++ b/workers/hugo-proxy/package.json
@@ -10,5 +10,8 @@
   "devDependencies": {
     "prettier": "^2.1.2"
   },
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "wrangler": "^2.0.16"
+  }
 }

--- a/workers/hugo-proxy/package.json
+++ b/workers/hugo-proxy/package.json
@@ -10,8 +10,8 @@
   "devDependencies": {
     "prettier": "^2.1.2"
   },
-  "main": "index.js",
   "dependencies": {
-    "wrangler": "^2.0.16"
+    "wrangler": "^2.0.16",
+    "esbuild": "^0.14.43"
   }
 }

--- a/workers/hugo-proxy/webpack.config.js
+++ b/workers/hugo-proxy/webpack.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  entry: __dirname + "/index.js",
-  mode: process.env.NODE_ENV || "none",
-};

--- a/workers/hugo-proxy/wrangler.toml
+++ b/workers/hugo-proxy/wrangler.toml
@@ -1,6 +1,6 @@
 name = "hugo-proxy"
-type = "webpack"
-webpack_config = "webpack.config.js"
+main = "build/worker.js"
+compatibility_date = "2022-07-01"
 workers_dev = true
 kv_namespaces = [
     { binding="CACHED_RESPONSES", id="145ec58b13f846faa2a105356c1b30ec" },

--- a/workers/nchlswhttkr-dot-com/build.sh
+++ b/workers/nchlswhttkr-dot-com/build.sh
@@ -2,10 +2,9 @@
 
 set -euo pipefail
 
-prettier --ignore-path "../../.prettierignore" --check "**/*.js"
+prettier --ignore-path "../../.prettierignore" --check "**/*.(js|json)"
 
-export CF_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
-export CF_API_TOKEN=$(pass show workers/cloudflare-api-token)
-export CF_ZONE_ID=$(pass show workers/cloudflare-zone-id-nchlswhttkr.com)
+export CLOUDFLARE_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
+export CLOUDFLARE_API_TOKEN=$(pass show workers/cloudflare-api-token)
 
-wrangler publish 2>&1
+wrangler publish

--- a/workers/nchlswhttkr-dot-com/package.json
+++ b/workers/nchlswhttkr-dot-com/package.json
@@ -1,17 +1,16 @@
 {
-    "name": "@nchlswhttkr/nchlswhttkr-dot-com",
-    "version": "0.1.0",
-    "description": "Handles redirects from my old domain to various destinations",
-    "scripts": {
-        "build": "source build.sh"
-    },
-    "license": "MIT",
-    "private": true,
-    "devDependencies": {
-        "prettier": "^2.1.2"
-    },
-    "main": "index.js",
-    "dependencies": {
-      "wrangler": "^2.0.16"
-    }
+  "name": "@nchlswhttkr/nchlswhttkr-dot-com",
+  "version": "0.1.0",
+  "description": "Handles redirects from my old domain to various destinations",
+  "scripts": {
+    "build": "source build.sh"
+  },
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "prettier": "^2.1.2"
+  },
+  "dependencies": {
+    "wrangler": "^2.0.16"
+  }
 }

--- a/workers/nchlswhttkr-dot-com/package.json
+++ b/workers/nchlswhttkr-dot-com/package.json
@@ -10,5 +10,8 @@
     "devDependencies": {
         "prettier": "^2.1.2"
     },
-    "main": "index.js"
+    "main": "index.js",
+    "dependencies": {
+      "wrangler": "^2.0.16"
+    }
 }

--- a/workers/nchlswhttkr-dot-com/wrangler.toml
+++ b/workers/nchlswhttkr-dot-com/wrangler.toml
@@ -1,3 +1,7 @@
 name = "nchlswhttkr-dot-com"
-type = "javascript"
-route = "*nchlswhttkr.com/*"
+main = "index.js"
+compatibility_date = "2022-07-01"
+routes = [
+    "nchlswhttkr.com/*",
+    "*.nchlswhttkr.com/*"
+]

--- a/workers/newsletter-subscription-form/build.sh
+++ b/workers/newsletter-subscription-form/build.sh
@@ -2,13 +2,12 @@
 
 set -euo pipefail
 
-prettier --ignore-path "../../.prettierignore" --check "**/*.js"
+prettier --ignore-path "../../.prettierignore" --check "**/*.(js|json)"
 
-export CF_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
-export CF_API_TOKEN=$(pass show workers/cloudflare-api-token)
-export CF_ZONE_ID=$(pass show workers/cloudflare-zone-id-nicholas.cloud)
+export CLOUDFLARE_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
+export CLOUDFLARE_API_TOKEN=$(pass show workers/cloudflare-api-token)
 
 pass show workers/newsletter-subscription-form/mailgun-api-key | wrangler secret put MAILGUN_API_KEY
 pass show workers/newsletter-subscription-form/email-signing-secret | wrangler secret put EMAIL_SIGNING_SECRET
 
-wrangler publish 2>&1
+wrangler publish

--- a/workers/newsletter-subscription-form/package.json
+++ b/workers/newsletter-subscription-form/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "prettier": "^2.1.2"
   },
-  "main": "index.js",
   "dependencies": {
     "wrangler": "^2.0.16"
   }

--- a/workers/newsletter-subscription-form/package.json
+++ b/workers/newsletter-subscription-form/package.json
@@ -10,5 +10,8 @@
   "devDependencies": {
     "prettier": "^2.1.2"
   },
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "wrangler": "^2.0.16"
+  }
 }

--- a/workers/newsletter-subscription-form/wrangler.toml
+++ b/workers/newsletter-subscription-form/wrangler.toml
@@ -1,3 +1,4 @@
 name = "newsletter-subscription-form"
-type = "javascript"
+main = "index.js"
+compatibility_date = "2022-07-01"
 route = "https://nicholas.cloud/newsletter/subscribe*"

--- a/workers/rss-feeds/build.sh
+++ b/workers/rss-feeds/build.sh
@@ -2,13 +2,13 @@
 
 set -euo pipefail
 
-prettier --ignore-path "../../.prettierignore" --check "**/*.js"
+prettier --ignore-path "../../.prettierignore" --check "**/*.(js|json)"
 
-export CF_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
-export CF_API_TOKEN=$(pass show workers/cloudflare-api-token)
+export CLOUDFLARE_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
+export CLOUDFLARE_API_TOKEN=$(pass show workers/cloudflare-api-token)
 
 mkdir -p build/handlebars
-handlebars feed.hbs -f build/handlebars/feed.hbs.js
-esbuild index.js --bundle --external:fs --outfile=build/worker/main.js --log-level="warning"
+handlebars feed.hbs -f build/feed.hbs.js
+esbuild index.js --bundle --external:fs --outfile=build/worker.js --log-level="warning"
 
-wrangler publish 2>&1
+wrangler publish

--- a/workers/rss-feeds/index.js
+++ b/workers/rss-feeds/index.js
@@ -5,7 +5,7 @@
  */
 global = {};
 Handlebars = require("handlebars");
-require("./build/handlebars/feed.hbs.js");
+require("./build/feed.hbs.js");
 
 import { getBandcampDailyArticles } from "./bandcamp-daily";
 

--- a/workers/rss-feeds/package.json
+++ b/workers/rss-feeds/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "prettier": "^2.1.2"
   },
-  "main": "build/worker/main.js",
   "dependencies": {
     "esbuild": "^0.14.43",
     "handlebars": "^4.7.7",

--- a/workers/rss-feeds/package.json
+++ b/workers/rss-feeds/package.json
@@ -13,6 +13,7 @@
   "main": "build/worker/main.js",
   "dependencies": {
     "esbuild": "^0.14.43",
-    "handlebars": "^4.7.7"
+    "handlebars": "^4.7.7",
+    "wrangler": "^2.0.16"
   }
 }

--- a/workers/rss-feeds/wrangler.toml
+++ b/workers/rss-feeds/wrangler.toml
@@ -1,3 +1,4 @@
 name = "rss-feeds"
-type = "javascript"
+main = "build/worker.js"
+compatibility_date = "2022-07-01"
 workers_dev = true

--- a/workers/terraform-registry/build.sh
+++ b/workers/terraform-registry/build.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-prettier --ignore-path "../../.prettierignore" --check "**/*.js"
+prettier --ignore-path "../../.prettierignore" --check "**/*.(js|json)"
+esbuild index.js --bundle --outfile="build/worker.js" --log-level="warning"
 
-export CF_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
-export CF_API_TOKEN=$(pass show workers/cloudflare-api-token)
-export CF_ZONE_ID=$(pass show workers/cloudflare-zone-id-nicholas.cloud)
+export CLOUDFLARE_ACCOUNT_ID=$(pass show workers/cloudflare-account-id)
+export CLOUDFLARE_API_TOKEN=$(pass show workers/cloudflare-api-token)
 
 git config user.signingkey | wrangler secret put GPG_KEY_ID
 
-wrangler publish 2>&1
+wrangler publish

--- a/workers/terraform-registry/index.js
+++ b/workers/terraform-registry/index.js
@@ -1,3 +1,9 @@
+/**
+ * A dependency of boom/call, hoek, references Node's Buffer API. Cloudflare
+ * rejects workers whose code references this unavailable API. Declaring a falsy
+ * value via an implicit global gets around this behaviour.
+ */
+Buffer = undefined;
 const Boom = require("@hapi/boom");
 const Call = require("@hapi/call");
 

--- a/workers/terraform-registry/package.json
+++ b/workers/terraform-registry/package.json
@@ -13,6 +13,7 @@
   "main": "index.js",
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@hapi/call": "^8.0.1"
+    "@hapi/call": "^8.0.1",
+    "wrangler": "^2.0.16"
   }
 }

--- a/workers/terraform-registry/package.json
+++ b/workers/terraform-registry/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "prettier": "^2.1.2"
   },
-  "main": "index.js",
   "dependencies": {
     "@hapi/boom": "^9.1.4",
     "@hapi/call": "^8.0.1",

--- a/workers/terraform-registry/wrangler.toml
+++ b/workers/terraform-registry/wrangler.toml
@@ -1,5 +1,6 @@
 name = "terraform-registry"
-type = "webpack"
+main = "build/worker.js"
+compatibility_date = "2022-07-01"
 workers_dev = false
 routes = [
     "https://nicholas.cloud/terraform-registry/*",


### PR DESCRIPTION
Rather than relying on a global install, Wrangler is now a direct dependency for each worker. Other changes are related to the new version's deprecation/migration guide.

* Webpack builds are no longer a feature of the toolchain, so I've switch over to esbuild
* The `route` pattern used by `nchlswhttkr-dot-com` isn't supported in the current iteration, but it can be worked around easily - see https://github.com/cloudflare/wrangler2/issues/605